### PR TITLE
Added clone trait to redis middleware and fixxed documentation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,7 @@ use actix_request_reply_cache::RedisCacheMiddlewareBuilder;
 async fn main() -> std::io::Result<()> {
     // Create the cache middleware with default settings
     let cache = RedisCacheMiddlewareBuilder::new("redis://127.0.0.1:6379")
-        .build()
-        .await;
+        .build();
         
     HttpServer::new(move || {
         App::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,7 @@ type CacheKeyFn = Arc<dyn Fn(&CacheContext) -> String + Send + Sync>;
 ///
 /// This middleware intercepts responses, caches them in Redis, and serves
 /// cached responses for subsequent matching requests when available.
+#[derive(Clone)]
 pub struct RedisCacheMiddleware {
     redis_conn: Option<MultiplexedConnection>,
     redis_url: String,


### PR DESCRIPTION
The clone trait was not implemented for the RedisCacheMiddleware struct, I added the trait to the RedisCacheMiddleware struct and also modified the documentation removing the await after build().